### PR TITLE
fix: fix TypeError: DataLoader() takes no arguments in quick_start/train.py

### DIFF
--- a/quick_start/train.py
+++ b/quick_start/train.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, List, Tuple
 
 import allennlp
 import torch
-from allennlp.data import DataLoader, DatasetReader, Instance, Vocabulary
+from allennlp.data import DataLoader, PyTorchDataLoader, DatasetReader, Instance, Vocabulary
 from allennlp.data.fields import LabelField, TextField
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
 from allennlp.data.tokenizers import Token, Tokenizer, WhitespaceTokenizer
@@ -142,8 +142,8 @@ def build_data_loaders(
     # Note that DataLoader is imported from allennlp above, *not* torch.
     # We need to get the allennlp-specific collate function, which is
     # what actually does indexing and batching.
-    train_loader = DataLoader(train_data, batch_size=8, shuffle=True)
-    dev_loader = DataLoader(dev_data, batch_size=8, shuffle=False)
+    train_loader = PyTorchDataLoader(train_data, batch_size=8, shuffle=True)
+    dev_loader = PyTorchDataLoader(dev_data, batch_size=8, shuffle=False)
     return train_loader, dev_loader
 
 


### PR DESCRIPTION
When I follow [guide](https://guide.allennlp.org/training-and-prediction#1), cloned allennlp-guide-examples and run python quick_start/train.py, It seems not work properly and raise a TypeError. It may because allennlp.data.DataLoader is an abstract class. In data loader used in real training loop, PyTorchDataLoader may be the right choice.